### PR TITLE
Update for Boost 1.89+: Replace deadline_timer with system_timer, bump CMake version, fix Windows linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 4.0)
 # XXX using 1.8.90 instead of 1.9.0-DEV
 project(nghttp2-asio VERSION 0.0.90)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,8 +57,12 @@ target_link_libraries(nghttp2_asio
   ${LIBNGHTTP2_LIBRARIES}
   ${OPENSSL_LIBRARIES}
   ${Boost_LIBRARIES}
-  ws2_32 mswsock
 )
+
+if (WIN32)
+  target_link_libraries(nghttp2_asio ws2_32 mswsock)
+endif()
+
 set_target_properties(nghttp2_asio PROPERTIES
   VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION})
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(nghttp2_asio
   ${LIBNGHTTP2_LIBRARIES}
   ${OPENSSL_LIBRARIES}
   ${Boost_LIBRARIES}
+  ws2_32 mswsock
 )
 set_target_properties(nghttp2_asio PROPERTIES
   VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION})

--- a/lib/asio_client_session_impl.cc
+++ b/lib/asio_client_session_impl.cc
@@ -68,7 +68,8 @@ session_impl::~session_impl() {
 
 void session_impl::start_resolve(const std::string &host,
                                  const std::string &service) {
-  deadline_.expires_from_now(connect_timeout_);
+  auto timeout_ms = std::chrono::milliseconds(connect_timeout_.total_milliseconds());
+  deadline_.expires_after(timeout_ms);
 
   auto self = shared_from_this();
 
@@ -91,11 +92,11 @@ void session_impl::handle_deadline() {
     return;
   }
 
-  if (deadline_.expires_at() <=
-      boost::asio::deadline_timer::traits_type::now()) {
+  if (deadline_.expiry() <=
+      std::chrono::system_clock::now()) {
     call_error_cb(boost::asio::error::timed_out);
     stop();
-    deadline_.expires_at(boost::posix_time::pos_infin);
+    deadline_.expires_at(std::chrono::system_clock::time_point::max());
     return;
   }
 
@@ -106,7 +107,7 @@ void session_impl::handle_deadline() {
 void handle_ping2(const boost::system::error_code &ec, int) {}
 
 void session_impl::start_ping() {
-  ping_.expires_from_now(boost::posix_time::seconds(30));
+  ping_.expires_after(std::chrono::seconds{30});
   ping_.async_wait(std::bind(&session_impl::handle_ping, shared_from_this(),
                              std::placeholders::_1));
 }
@@ -622,7 +623,8 @@ void session_impl::do_read() {
     return;
   }
 
-  deadline_.expires_from_now(read_timeout_);
+  auto timeout_ms = std::chrono::milliseconds(read_timeout_.total_milliseconds());
+  deadline_.expires_after(timeout_ms);
 
   auto self = this->shared_from_this();
 
@@ -719,7 +721,8 @@ void session_impl::do_write() {
 
   // Reset read deadline here, because normally client is sending
   // something, it does not expect timeout while doing it.
-  deadline_.expires_from_now(read_timeout_);
+  auto timeout_ms = std::chrono::milliseconds(read_timeout_.total_milliseconds());
+  deadline_.expires_after(timeout_ms);
 
   auto self = this->shared_from_this();
 

--- a/lib/asio_client_session_impl.h
+++ b/lib/asio_client_session_impl.h
@@ -120,11 +120,11 @@ private:
   connect_cb connect_cb_;
   error_cb error_cb_;
 
-  boost::asio::deadline_timer deadline_;
+  boost::asio::system_timer deadline_;
   boost::posix_time::time_duration connect_timeout_;
   boost::posix_time::time_duration read_timeout_;
 
-  boost::asio::deadline_timer ping_;
+  boost::asio::system_timer ping_;
 
   nghttp2_session *session_;
 

--- a/lib/asio_server_connection.h
+++ b/lib/asio_server_connection.h
@@ -101,13 +101,15 @@ public:
   socket_type &socket() { return socket_; }
 
   void start_tls_handshake_deadline() {
-    deadline_.expires_from_now(tls_handshake_timeout_);
+    auto timeout_ms = std::chrono::milliseconds(tls_handshake_timeout_.total_milliseconds());
+    deadline_.expires_after(timeout_ms);
     deadline_.async_wait(
         std::bind(&connection::handle_deadline, this->shared_from_this()));
   }
 
   void start_read_deadline() {
-    deadline_.expires_from_now(read_timeout_);
+    auto timeout_ms = std::chrono::milliseconds(read_timeout_.total_milliseconds());
+    deadline_.expires_after(timeout_ms);
     deadline_.async_wait(
         std::bind(&connection::handle_deadline, this->shared_from_this()));
   }
@@ -117,10 +119,10 @@ public:
       return;
     }
 
-    if (deadline_.expires_at() <=
-        boost::asio::deadline_timer::traits_type::now()) {
+    if (deadline_.expiry() <=
+        std::chrono::system_clock::now()) {
       stop();
-      deadline_.expires_at(boost::posix_time::pos_infin);
+      deadline_.expires_at(std::chrono::system_clock::time_point::max());
       return;
     }
 
@@ -131,7 +133,8 @@ public:
   void do_read() {
     auto self = this->shared_from_this();
 
-    deadline_.expires_from_now(read_timeout_);
+    auto timeout_ms = std::chrono::milliseconds(read_timeout_.total_milliseconds());
+    deadline_.expires_after(timeout_ms);
 
     socket_.async_read_some(
         boost::asio::buffer(buffer_),
@@ -192,7 +195,8 @@ public:
 
     // Reset read deadline here, because normally client is sending
     // something, it does not expect timeout while doing it.
-    deadline_.expires_from_now(read_timeout_);
+    auto timeout_ms = std::chrono::milliseconds(read_timeout_.total_milliseconds());
+    deadline_.expires_after(timeout_ms);
 
     boost::asio::async_write(
         socket_, boost::asio::buffer(outbuf_, nwrite),
@@ -236,7 +240,7 @@ private:
 
   boost::array<uint8_t, 64_k> outbuf_;
 
-  boost::asio::deadline_timer deadline_;
+  boost::asio::system_timer deadline_;
   boost::posix_time::time_duration tls_handshake_timeout_;
   boost::posix_time::time_duration read_timeout_;
 

--- a/lib/includes/nghttp2/asio_http2_client.h
+++ b/lib/includes/nghttp2/asio_http2_client.h
@@ -26,6 +26,7 @@
 #define ASIO_HTTP2_CLIENT_H
 
 #include <nghttp2/asio_http2.h>
+#include <boost/date_time.hpp>
 
 namespace nghttp2 {
 

--- a/lib/includes/nghttp2/asio_http2_server.h
+++ b/lib/includes/nghttp2/asio_http2_server.h
@@ -26,6 +26,7 @@
 #define ASIO_HTTP2_SERVER_H
 
 #include <nghttp2/asio_http2.h>
+#include <boost/date_time.hpp>
 
 namespace nghttp2 {
 

--- a/lib/util.cc
+++ b/lib/util.cc
@@ -173,9 +173,15 @@ std::string http_date(time_t t) {
 char *http_date(char *res, time_t t) {
   struct tm tms;
 
+#if defined(_WIN32) || defined(_MSC_VER)
+  if (gmtime_s(&tms, &t) != 0) {
+    return res;
+  }
+#else
   if (gmtime_r(&t, &tms) == nullptr) {
     return res;
   }
+#endif
 
   auto p = res;
 


### PR DESCRIPTION
This PR updates nghttp2-asio to work with Boost 1.89 and newer.

## Changes

Boost Asio update: Replaced deprecated `boost::asio::deadline_timer` with `boost::asio::system_timer`.

CMake update: Bumped minimum required CMake version from 3.0 to 4.0 for better compatibility with modern toolchains.

Windows build fix: Added mswsock and ws2_32 to the link libraries to resolve missing symbol errors on Windows.

## Testing

Successfully built and tested on MSYS2 (both Debug and Release).

Verified that builds work with Boost 1.89+.

## Notes

This PR is backward-compatible with older Boost versions (>= 1.70), as system_timer has been available for a long time.

No API changes for library users — this is purely a build-system and internal update.